### PR TITLE
CBA-156: awscloud profile, excluding aws key and secret (coming from …

### DIFF
--- a/services/distribution/src/main/resources/application-awscloud.yaml
+++ b/services/distribution/src/main/resources/application-awscloud.yaml
@@ -1,0 +1,19 @@
+---
+spring:
+  flyway:
+    password: ${POSTGRESQL_PASSWORD_FLYWAY}
+    user: ${POSTGRESQL_USER_FLYWAY}
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    username: ${POSTGRESQL_USER_DISTRIBUTION}
+    password: ${POSTGRESQL_PASSWORD_DISTRIBUTION}
+
+services:
+  distribution:
+    paths:
+      output: /tmp/distribution
+    objectstore:
+      endpoint: ${CWA_OBJECTSTORE_ENDPOINT}
+      bucket: ${CWA_OBJECTSTORE_BUCKET}
+      port: ${CWA_OBJECTSTORE_PORT}
+      set-public-read-acl-on-put-object: false


### PR DESCRIPTION
introducing `awscloud` profile that ommits the `access-key` and `secret-key` and sets the `set-public-read-acl-on-put-object` to false.

originall cloud profile is no longer required.