### PR TITLE
CBA-466: fix out of bounds risk calculation value (8). backend sets i…

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -45,6 +45,8 @@ public class DiagnosisKeyBuilder implements
     Builder, RollingStartIntervalNumberBuilder, TransmissionRiskLevelBuilder, FinalBuilder {
 
   private static final Logger logger = LoggerFactory.getLogger(DiagnosisKeyBuilder.class);
+  public static final int INVALID_MAX_TRANSMISSION_RISK_LEVEL = 8;
+  public static final int MAX_TRANSMISSION_RISK_LEVEL = 7;
 
   private byte[] keyData;
   private int rollingStartIntervalNumber;
@@ -85,8 +87,13 @@ public class DiagnosisKeyBuilder implements
     return this
         .withKeyData(protoBufObject.getKeyData().toByteArray())
         .withRollingStartIntervalNumber(protoBufObject.getRollingStartIntervalNumber())
-        .withTransmissionRiskLevel(protoBufObject.getTransmissionRiskLevel())
+        .withTransmissionRiskLevel(performCorrectionOnTransmissionRiskLevel(protoBufObject))
         .withRollingPeriod(protoBufObject.getRollingPeriod());
+  }
+
+  private int performCorrectionOnTransmissionRiskLevel(TemporaryExposureKey protoBufObject) {
+    return protoBufObject.getTransmissionRiskLevel() == INVALID_MAX_TRANSMISSION_RISK_LEVEL
+        ? MAX_TRANSMISSION_RISK_LEVEL : protoBufObject.getTransmissionRiskLevel();
   }
 
   @Override


### PR DESCRIPTION
We discovered a bug in the German risk calculation whereby out of bounds values are used (8).

The proposed solution:
- replace 8 with 7 in the code on iOS / Android
- automatically replace all uploaded 8 values in TEK’s with 7 on the server
- run an update script to replace all 8 values on the CDN with 7

This PR takes care of the second bullet