### PR TITLE
CBA-488: migration risk level 8 -> 7

### DIFF
--- a/common/persistence/src/main/resources/derivation-maps.yaml
+++ b/common/persistence/src/main/resources/derivation-maps.yaml
@@ -1,7 +1,7 @@
 # This externalised configuration is used for deriving missing values of Temporary Exposure Key fields
 # in modules that represent diagnosis key input channels.
 tek-field-derivations:
-  # As of version 1.5, EFGS can send DSOS values for which there is no TRL mapped, thus 
+  # As of version 1.5, EFGS can send DSOS values for which there is no TRL mapped, thus
   # we need a system-wide configurable default for TRL
   default-trl: ${DEFAULT_TRL:1}
   # Map containing the derived values of DSOS (days since onset of symptoms) from TRL (transmission risk level)
@@ -22,35 +22,35 @@ tek-field-derivations:
     -4: 4
     -3: 6
     -2: 7
-    -1: 8
-    0: 8 
-    1: 8
+    -1: 7
+    0: 7
+    1: 7
     2: 6
     3: 5
     4: 3
     6: 2
     5: 2
     196: 2
-    197: 3 
+    197: 3
     198: 4
     199: 5
     200: 7
-    201: 8
-    202: 8
-    203: 8
+    201: 7
+    202: 7
+    203: 7
     204: 7
     205: 5
     206: 3
     207: 2
     296: 2
-    297: 2 
+    297: 2
     298: 3
     299: 5
     300: 6
     301: 7
-    302: 8
-    303: 8
-    304: 8
+    302: 7
+    303: 7
+    304: 7
     305: 6
     306: 4
     307: 3
@@ -60,8 +60,8 @@ tek-field-derivations:
     398: 5
     399: 6
     400: 7
-    401: 8
-    402: 8
+    401: 7
+    402: 7
     403: 7
     404: 5
     405: 4
@@ -72,8 +72,8 @@ tek-field-derivations:
     499: 5
     500: 7
     501: 7
-    502: 8
-    503: 8
+    502: 7
+    503: 7
     504: 6
     505: 5
     506: 3
@@ -85,7 +85,7 @@ tek-field-derivations:
     600: 6
     601: 7
     602: 7
-    603: 8
+    603: 7
     604: 7
     605: 6
     606: 4
@@ -277,9 +277,9 @@ tek-field-derivations:
     1993: 3
     1994: 4
     1995: 7
-    1996: 8
-    1997: 8
-    1998: 8
+    1996: 7
+    1997: 7
+    1998: 7
     1999: 6
     2000: 5
     2097: 2
@@ -287,7 +287,7 @@ tek-field-derivations:
     2099: 4
     3000: 4
     3992: 2
-    3993: 3   
+    3993: 3
     3994: 4
     3995: 6
     3996: 7


### PR DESCRIPTION
To cope with the current mobile risk calculation, transmission level 8 is not supported and should be converted to level 7 before  sending it to CDN (and mobile apps)