### PR TITLE
Pre-release v1.4.13: log4j2 fix (2.17.0)

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -83,10 +83,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -83,12 +83,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>


### PR DESCRIPTION
Bump log4j2 to 2.17.0